### PR TITLE
fix: 🐛 Add pillow dependency for PIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each resource should include:
 ## Local Development
 
 1. Ensure Python 3.9+ is installed
-2. Install dependencies: `pip install pyyaml jinja2 requests python-dotenv selenium webdriver-manager`
+2. Install dependencies: `pip install pyyaml jinja2 requests python-dotenv selenium webdriver-manager pillow`
 3. Run site generation: `python generate_site.py`
 
 ## Code of Conduct


### PR DESCRIPTION
The PIL dependency is missing after run `pip install pyyaml jinja2 requests python-dotenv selenium webdriver-manager`:

I've just add the `pillow` dependency.